### PR TITLE
Wrap file-open calls inside assert statements

### DIFF
--- a/library/factorioloader.lua
+++ b/library/factorioloader.lua
@@ -114,7 +114,7 @@ function dep_base(dep)
 end
 
 function Loader.getModList(mod_dir)
-    local f = io.open(mod_dir .. "/mod-list.json")
+    local f = assert(io.open(mod_dir .. "/mod-list.json"))
     local s = f:read("*a")
     local modlist = JSON:decode(s)
     f:close()
@@ -197,7 +197,7 @@ local ZipModLoader = {}
 ZipModLoader.__index = ZipModLoader
 function ZipModLoader.new(dirname, mod_name)
     local filename = dirname .. mod_name .. ".zip"
-    local arc = zip.open(filename)
+    local arc = assert(zip.open(filename))
     local mod = {
         mod_name = mod_name .. "/",
         archive = arc,
@@ -230,7 +230,7 @@ function ZipModule.new(dirname, mod_name)
         dirname = dirname .. "/"
     end
     local filename = dirname .. mod_name .. ".zip"
-    local arc = zip.open(filename)
+    local arc = assert(zip.open(filename))
     local info_filename = mod_name .. "/info.json"
     local f = arc:open(mod_name .. "/info.json")
     local info = JSON:decode(f:read("*a"))


### PR DESCRIPTION
Simply because they show nicer error messages which include the file name instead of the unhelpful "attempt to index local 'varname' (a nil value)".