### PR TITLE
Prevent crash if mod-settings.dat doesn't exist

### DIFF
--- a/library/settingloader.lua
+++ b/library/settingloader.lua
@@ -69,6 +69,9 @@ end
 
 function SettingLoader.load(filename)
     local f = io.open(filename, "rb")
+    if(f == nil) then
+        return {}
+    end
     local version = readAll(f, 8)
     local settings = SettingLoader.readPropertyTree(f, 0)
     f:close()

--- a/library/settingloader.lua
+++ b/library/settingloader.lua
@@ -69,7 +69,7 @@ end
 
 function SettingLoader.load(filename)
     local f = io.open(filename, "rb")
-    if(f == nil) then
+    if f == nil then
         return {}
     end
     local version = readAll(f, 8)


### PR DESCRIPTION
If none of the mods in the mod-directory have any (non-default) settings, mod-settings.dat might not exists. Therefore the absence of said file should not cause any errors.