### PR TITLE
More fixes for mod-compatibility

### DIFF
--- a/LICENCE.externals
+++ b/LICENCE.externals
@@ -1,4 +1,3 @@
-
 externals/inspect.lua
 ========================================
 See https://github.com/kikito/inspect.lua
@@ -35,4 +34,34 @@ See http://regex.info/blog/lua/json
 Creative Commons Attribution 3.0 Unported License.
 
 http://creativecommons.org/licenses/by/3.0/deed.en_US
+-----------------------------------------------------------------------
+
+
+
+externals/serpent.lua
+=========================================
+See https://github.com/pkulchenko/serpent
+-----------------------------------------------------------------------
+
+Serpent source is released under the MIT License
+
+Copyright (c) 2012-2018 Paul Kulchenko (paul@kulchenko.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 -----------------------------------------------------------------------

--- a/externals/serpent.lua
+++ b/externals/serpent.lua
@@ -1,0 +1,140 @@
+local n, v = "serpent", "0.302" -- (C) 2012-18 Paul Kulchenko; MIT License
+local c, d = "Paul Kulchenko", "Lua serializer and pretty printer"
+local snum = {[tostring(1/0)]='1/0 --[[math.huge]]',[tostring(-1/0)]='-1/0 --[[-math.huge]]',[tostring(0/0)]='0/0'}
+local badtype = {thread = true, userdata = true, cdata = true}
+local getmetatable = debug and debug.getmetatable or getmetatable
+local pairs = function(t) return next, t end -- avoid using __pairs in Lua 5.2+
+local keyword, globals, G = {}, {}, (_G or _ENV)
+for _,k in ipairs({'and', 'break', 'do', 'else', 'elseif', 'end', 'false',
+  'for', 'function', 'goto', 'if', 'in', 'local', 'nil', 'not', 'or', 'repeat',
+  'return', 'then', 'true', 'until', 'while'}) do keyword[k] = true end
+for k,v in pairs(G) do globals[v] = k end -- build func to name mapping
+for _,g in ipairs({'coroutine', 'debug', 'io', 'math', 'string', 'table', 'os'}) do
+  for k,v in pairs(type(G[g]) == 'table' and G[g] or {}) do globals[v] = g..'.'..k end end
+
+local function s(t, opts)
+  local name, indent, fatal, maxnum = opts.name, opts.indent, opts.fatal, opts.maxnum
+  local sparse, custom, huge = opts.sparse, opts.custom, not opts.nohuge
+  local space, maxl = (opts.compact and '' or ' '), (opts.maxlevel or math.huge)
+  local maxlen, metatostring = tonumber(opts.maxlength), opts.metatostring
+  local iname, comm = '_'..(name or ''), opts.comment and (tonumber(opts.comment) or math.huge)
+  local numformat = opts.numformat or "%.17g"
+  local seen, sref, syms, symn = {}, {'local '..iname..'={}'}, {}, 0
+  local function gensym(val) return '_'..(tostring(tostring(val)):gsub("[^%w]",""):gsub("(%d%w+)",
+    -- tostring(val) is needed because __tostring may return a non-string value
+    function(s) if not syms[s] then symn = symn+1; syms[s] = symn end return tostring(syms[s]) end)) end
+  local function safestr(s) return type(s) == "number" and tostring(huge and snum[tostring(s)] or numformat:format(s))
+    or type(s) ~= "string" and tostring(s) -- escape NEWLINE/010 and EOF/026
+    or ("%q"):format(s):gsub("\010","n"):gsub("\026","\\026") end
+  local function comment(s,l) return comm and (l or 0) < comm and ' --[['..select(2, pcall(tostring, s))..']]' or '' end
+  local function globerr(s,l) return globals[s] and globals[s]..comment(s,l) or not fatal
+    and safestr(select(2, pcall(tostring, s))) or error("Can't serialize "..tostring(s)) end
+  local function safename(path, name) -- generates foo.bar, foo[3], or foo['b a r']
+    local n = name == nil and '' or name
+    local plain = type(n) == "string" and n:match("^[%l%u_][%w_]*$") and not keyword[n]
+    local safe = plain and n or '['..safestr(n)..']'
+    return (path or '')..(plain and path and '.' or '')..safe, safe end
+  local alphanumsort = type(opts.sortkeys) == 'function' and opts.sortkeys or function(k, o, n) -- k=keys, o=originaltable, n=padding
+    local maxn, to = tonumber(n) or 12, {number = 'a', string = 'b'}
+    local function padnum(d) return ("%0"..tostring(maxn).."d"):format(tonumber(d)) end
+    table.sort(k, function(a,b)
+      -- sort numeric keys first: k[key] is not nil for numerical keys
+      return (k[a] ~= nil and 0 or to[type(a)] or 'z')..(tostring(a):gsub("%d+",padnum))
+           < (k[b] ~= nil and 0 or to[type(b)] or 'z')..(tostring(b):gsub("%d+",padnum)) end) end
+  local function val2str(t, name, indent, insref, path, plainindex, level)
+    local ttype, level, mt = type(t), (level or 0), getmetatable(t)
+    local spath, sname = safename(path, name)
+    local tag = plainindex and
+      ((type(name) == "number") and '' or name..space..'='..space) or
+      (name ~= nil and sname..space..'='..space or '')
+    if seen[t] then -- already seen this element
+      sref[#sref+1] = spath..space..'='..space..seen[t]
+      return tag..'nil'..comment('ref', level) end
+    -- protect from those cases where __tostring may fail
+    if type(mt) == 'table' and metatostring ~= false then
+      local to, tr = pcall(function() return mt.__tostring(t) end)
+      local so, sr = pcall(function() return mt.__serialize(t) end)
+      if (to or so) then -- knows how to serialize itself
+        seen[t] = insref or spath
+        t = so and sr or tr
+        ttype = type(t)
+      end -- new value falls through to be serialized
+    end
+    if ttype == "table" then
+      if level >= maxl then return tag..'{}'..comment('maxlvl', level) end
+      seen[t] = insref or spath
+      if next(t) == nil then return tag..'{}'..comment(t, level) end -- table empty
+      if maxlen and maxlen < 0 then return tag..'{}'..comment('maxlen', level) end
+      local maxn, o, out = math.min(#t, maxnum or #t), {}, {}
+      for key = 1, maxn do o[key] = key end
+      if not maxnum or #o < maxnum then
+        local n = #o -- n = n + 1; o[n] is much faster than o[#o+1] on large tables
+        for key in pairs(t) do if o[key] ~= key then n = n + 1; o[n] = key end end end
+      if maxnum and #o > maxnum then o[maxnum+1] = nil end
+      if opts.sortkeys and #o > maxn then alphanumsort(o, t, opts.sortkeys) end
+      local sparse = sparse and #o > maxn -- disable sparsness if only numeric keys (shorter output)
+      for n, key in ipairs(o) do
+        local value, ktype, plainindex = t[key], type(key), n <= maxn and not sparse
+        if opts.valignore and opts.valignore[value] -- skip ignored values; do nothing
+        or opts.keyallow and not opts.keyallow[key]
+        or opts.keyignore and opts.keyignore[key]
+        or opts.valtypeignore and opts.valtypeignore[type(value)] -- skipping ignored value types
+        or sparse and value == nil then -- skipping nils; do nothing
+        elseif ktype == 'table' or ktype == 'function' or badtype[ktype] then
+          if not seen[key] and not globals[key] then
+            sref[#sref+1] = 'placeholder'
+            local sname = safename(iname, gensym(key)) -- iname is table for local variables
+            sref[#sref] = val2str(key,sname,indent,sname,iname,true) end
+          sref[#sref+1] = 'placeholder'
+          local path = seen[t]..'['..tostring(seen[key] or globals[key] or gensym(key))..']'
+          sref[#sref] = path..space..'='..space..tostring(seen[value] or val2str(value,nil,indent,path))
+        else
+          out[#out+1] = val2str(value,key,indent,nil,seen[t],plainindex,level+1)
+          if maxlen then
+            maxlen = maxlen - #out[#out]
+            if maxlen < 0 then break end
+          end
+        end
+      end
+      local prefix = string.rep(indent or '', level)
+      local head = indent and '{\n'..prefix..indent or '{'
+      local body = table.concat(out, ','..(indent and '\n'..prefix..indent or space))
+      local tail = indent and "\n"..prefix..'}' or '}'
+      return (custom and custom(tag,head,body,tail,level) or tag..head..body..tail)..comment(t, level)
+    elseif badtype[ttype] then
+      seen[t] = insref or spath
+      return tag..globerr(t, level)
+    elseif ttype == 'function' then
+      seen[t] = insref or spath
+      if opts.nocode then return tag.."function() --[[..skipped..]] end"..comment(t, level) end
+      local ok, res = pcall(string.dump, t)
+      local func = ok and "((loadstring or load)("..safestr(res)..",'@serialized'))"..comment(t, level)
+      return tag..(func or globerr(t, level))
+    else return tag..safestr(t) end -- handle all other types
+  end
+  local sepr = indent and "\n" or ";"..space
+  local body = val2str(t, name, indent) -- this call also populates sref
+  local tail = #sref>1 and table.concat(sref, sepr)..sepr or ''
+  local warn = opts.comment and #sref>1 and space.."--[[incomplete output with shared/self-references skipped]]" or ''
+  return not name and body..warn or "do local "..body..sepr..tail.."return "..name..sepr.."end"
+end
+
+local function deserialize(data, opts)
+  local env = (opts and opts.safe == false) and G
+    or setmetatable({}, {
+        __index = function(t,k) return t end,
+        __call = function(t,...) error("cannot call functions") end
+      })
+  local f, res = (loadstring or load)('return '..data, nil, nil, env)
+  if not f then f, res = (loadstring or load)(data, nil, nil, env) end
+  if not f then return f, res end
+  if setfenv then setfenv(f, env) end
+  return pcall(f)
+end
+
+local function merge(a, b) if b then for k,v in pairs(b) do a[k] = v end end; return a; end
+return { _NAME = n, _COPYRIGHT = c, _DESCRIPTION = d, _VERSION = v, serialize = s,
+  load = deserialize,
+  dump = function(a, opts) return s(a, merge({name = '_', compact = true, sparse = true}, opts)) end,
+  line = function(a, opts) return s(a, merge({sortkeys = true, comment = true}, opts)) end,
+  block = function(a, opts) return s(a, merge({indent = '  ', sortkeys = true, comment = true}, opts)) end }

--- a/library/ZipModLoader.lua
+++ b/library/ZipModLoader.lua
@@ -1,6 +1,8 @@
 local ZipModLoader = {}
 ZipModLoader.__index = ZipModLoader
 
+local directory_stack = {}
+
 function ZipModLoader.new(dirname, mod_name, arc_subfolder)
     local filename = dirname .. mod_name .. ".zip"
     local arc = assert(zip.open(filename))
@@ -15,14 +17,31 @@ end
 
 function ZipModLoader:__call(name)
     name = string.gsub(name, "%.", "/")
-    local filename = self.arc_subfolder .. name .. ".lua"
-    local file = self.archive:open(filename)
+    local potential_files = { self.arc_subfolder .. name .. ".lua" }
+    if #directory_stack ~= 0 then
+        table.insert(potential_files, directory_stack[#directory_stack] .. name .. ".lua")
+    end
+    local file = nil
+    local filename = nil
+    for _, f in ipairs(potential_files) do
+        file = self.archive:open(f)
+        if file then
+            filename = f
+            break
+        end
+    end
     if not file then
-        return "Not found: " .. filename .. " in " .. self.archive_name
+        return "Not found: " .. name .. " in " .. self.archive_name
     end
     local content = file:read("*a")
     file:close()
-    return load(content, filename)
+    local loaded_chunk = load(content, filename)
+    return function()
+        table.insert(directory_stack, filename:sub(1, filename:find("/[^/]*$")))
+        local result = loaded_chunk()
+        table.remove(directory_stack)
+        return result
+    end
 end
 
 function ZipModLoader:close()

--- a/library/ZipModLoader.lua
+++ b/library/ZipModLoader.lua
@@ -1,0 +1,32 @@
+local ZipModLoader = {}
+ZipModLoader.__index = ZipModLoader
+
+function ZipModLoader.new(dirname, mod_name, arc_subfolder)
+    local filename = dirname .. mod_name .. ".zip"
+    local arc = assert(zip.open(filename))
+    local mod = {
+        mod_name = mod_name .. "/",
+        archive = arc,
+        archive_name = filename,
+        arc_subfolder = arc_subfolder,
+    }
+    return setmetatable(mod, ZipModLoader)
+end
+
+function ZipModLoader:__call(name)
+    name = string.gsub(name, "%.", "/")
+    local filename = self.arc_subfolder .. name .. ".lua"
+    local file = self.archive:open(filename)
+    if not file then
+        return "Not found: " .. filename .. " in " .. self.archive_name
+    end
+    local content = file:read("*a")
+    file:close()
+    return load(content, filename)
+end
+
+function ZipModLoader:close()
+    self.archive:close()
+end
+
+return ZipModLoader

--- a/library/factorioglobals.lua
+++ b/library/factorioglobals.lua
@@ -1,0 +1,14 @@
+defines = require("library/defines")
+serpent = require("externals/serpent")
+
+function log(s)
+    io.stderr:write(s .. "\n")
+end
+
+function table_size(t)
+    local size = 0
+    for _ in pairs(t) do
+        size = size + 1
+    end
+    return size
+end

--- a/library/factorioloader.lua
+++ b/library/factorioloader.lua
@@ -6,6 +6,7 @@ require("lfs")
 require("zip")
 
 defines = require("library/defines")
+serpent = require("externals/serpent")
 local CFGParser = require("library/cfgparser")
 local SettingLoader = require("library/settingloader")
 mods = {}

--- a/library/factorioloader.lua
+++ b/library/factorioloader.lua
@@ -1,12 +1,12 @@
 local Loader = {}
 
+require("library/factorioglobals")
+
 JSON = require("externals/JSON") -- needed for the info.json-file
 
 require("lfs")
 require("zip")
 
-defines = require("library/defines")
-serpent = require("externals/serpent")
 local CFGParser = require("library/cfgparser")
 local SettingLoader = require("library/settingloader")
 local ZipModLoader = require("library/ZipModLoader")
@@ -14,18 +14,6 @@ mods = {}
 
 function endswith(s, sub)
     return string.sub(s, -string.len(sub)) == sub
-end
-
-function log(s)
-    io.stderr:write(s .. "\n")
-end
-
-function table_size(t)
-    local size = 0
-    for _ in pairs(t) do
-        size = size + 1
-    end
-    return size
 end
 
 --- Loads Factorio data files from a list of mods.

--- a/library/factorioloader.lua
+++ b/library/factorioloader.lua
@@ -115,7 +115,7 @@ end
 
 function dep_base(dep)
     dep = string.gsub(dep, "^%?%s+", "")
-    local i = string.find(dep, " ")
+    local i = string.find(dep, "%s*[=><].*")
     if i == nil then
         return dep
     end

--- a/library/factorioloader.lua
+++ b/library/factorioloader.lua
@@ -19,6 +19,14 @@ function log(s)
     io.stderr:write(s .. "\n")
 end
 
+function table_size(t)
+    local size = 0
+    for _ in pairs(t) do
+        size = size + 1
+    end
+    return size
+end
+
 --- Loads Factorio data files from a list of mods.
 -- executes all module loaders (data.lua),
 -- they do some stuff and extend the global variable "data",

--- a/library/factorioloader.lua
+++ b/library/factorioloader.lua
@@ -159,6 +159,10 @@ local function getDeps(module_info, name)
     if mod.deps then
         return mod.deps
     end
+    if not mod.dependencies then
+        -- no dependencies were declared in info.json
+        mod.dependencies = {}
+    end
     local deps = {}
     --table.insert(deps, mod)
     for _, raw_dep in ipairs(mod.dependencies) do

--- a/library/factorioloader.lua
+++ b/library/factorioloader.lua
@@ -9,6 +9,7 @@ defines = require("library/defines")
 serpent = require("externals/serpent")
 local CFGParser = require("library/cfgparser")
 local SettingLoader = require("library/settingloader")
+local ZipModLoader = require("library/ZipModLoader")
 mods = {}
 
 function endswith(s, sub)
@@ -246,34 +247,6 @@ function Module:locale(locales)
             end
         end
     end
-end
-
-local ZipModLoader = {}
-ZipModLoader.__index = ZipModLoader
-function ZipModLoader.new(dirname, mod_name, arc_subfolder)
-    local filename = dirname .. mod_name .. ".zip"
-    local arc = assert(zip.open(filename))
-    local mod = {
-        mod_name = mod_name .. "/",
-        archive = arc,
-        archive_name = filename,
-        arc_subfolder = arc_subfolder,
-    }
-    return setmetatable(mod, ZipModLoader)
-end
-function ZipModLoader:__call(name)
-    name = string.gsub(name, "%.", "/")
-    local filename = self.arc_subfolder .. name .. ".lua"
-    local file = self.archive:open(filename)
-    if not file then
-        return "Not found: " .. filename .. " in " .. self.archive_name
-    end
-    local content = file:read("*a")
-    file:close()
-    return load(content, filename)
-end
-function ZipModLoader:close()
-    self.archive:close()
 end
 
 ZipModule = {}

--- a/library/factorioloader.lua
+++ b/library/factorioloader.lua
@@ -42,6 +42,7 @@ function Loader.load_data(game_path, mod_dir)
                 local info = ZipModule.new(mod_dir, string.sub(filename, 1, -5))
                 module_info[mod_name] = info
             else
+                error("Loading unzipped mods is not supported at the moment.")
             end
         end
     end

--- a/library/settingloader.lua
+++ b/library/settingloader.lua
@@ -18,6 +18,10 @@ function SettingLoader.readBool(f)
     return SettingLoader.readByte(f) == 1
 end
 
+function SettingLoader.readUshort(f)
+    return string.unpack("<I2", readAll(f, 2))
+end
+
 function SettingLoader.readInt(f)
     return string.unpack("<i4", readAll(f, 4))
 end
@@ -70,9 +74,22 @@ end
 function SettingLoader.load(filename)
     local f = io.open(filename, "rb")
     if f == nil then
-        return {}
+        return {
+            ["startup"] = {},
+            ["runtime-global"] = {},
+            ["runtime-per-user"] = {}
+        }
     end
-    local version = readAll(f, 8)
+    local version = {
+        major = SettingLoader.readUshort(f),
+        minor = SettingLoader.readUshort(f),
+        patch = SettingLoader.readUshort(f),
+        map = SettingLoader.readUshort(f)
+    }
+    if (version.major == 0 and version.minor >= 17) or version.major >= 1 then
+        -- read extranous byte present since 0.17
+        readAll(f, 1)
+    end
     local settings = SettingLoader.readPropertyTree(f, 0)
     f:close()
     return settings

--- a/library/settingloader.lua
+++ b/library/settingloader.lua
@@ -87,7 +87,7 @@ function SettingLoader.load(filename)
         map = SettingLoader.readUshort(f)
     }
     if (version.major == 0 and version.minor >= 17) or version.major >= 1 then
-        -- read extranous byte present since 0.17
+        -- ignore extranous byte present since 0.17
         readAll(f, 1)
     end
     local settings = SettingLoader.readPropertyTree(f, 0)


### PR DESCRIPTION
These are all the issues I found in the Seablock modpack. Together with KirkMcDonald/factorio-tools#5 the at least data dumper pipeline now generates a seemingly correct looking JSON for Seablock.

Details for the non-obvious things are in each commits message. The commits are in the order the problems occurred/were masking each other.

Mod without dependency field: e.g. [KS Power](https://github.com/Klonan/KS_Power/blob/299468d246007029dc9265a30c3dc8f289153058/info.json)
Mod names with spaces: e.g. [A Sea Block Config](https://mods.factorio.com/mod/A%20Sea%20Block%20Config) and [Nuclear Fuel](https://mods.factorio.com/mod/Nuclear%20Fuel)
File relative requires are happening e.g. in [Angel's Refining](https://github.com/Arch666Angel/ModsCurrentGit/blob/aa64337ba0ff0aef762db66e606f7d906fa411d9/angelsrefining_0.9.14/prototypes/override-functions.lua#L1)
Regarding Serpent and `table_size()`, I don't know anymore where exactly they were used, but it's a pretty straightforward addition I guess.

The changes to the `require()` logic are clearly a hack. Using the call stack is the best idea I could come up with though. If you see a better way, please let me know. If if stays like this I'll do some refactoring to get rid of the code duplication currently in that commit.

Also: Is it intentional/known that loading unzipped mods is currently not working? It's just one line missing [here](https://github.com/KirkMcDonald/FactorioLoaderLib/blob/3290dd16af141633bc6093a59527b11255c84a43/library/factorioloader.lua#L46-L47), so I thought it might have happened by accident. If that's the case then I still need to adjust the require logic for the non-zipped case as well.

More special `require()` logic is coming for 0.17 as well btw, see #6.